### PR TITLE
Rename debug route handler for clarity

### DIFF
--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -4,5 +4,5 @@ from services.debug_service import DebugService
 router = APIRouter()
 
 @router.get("/")
-def get_config():
+def get_debug_summary():
     return DebugService().do_debug()

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -1,9 +1,13 @@
+from typing import Any, Dict
+
 from fastapi import APIRouter
+
 from services.debug_service import DebugService
 
 router = APIRouter()
 
 @router.get("/")
-def get_debug_summary():
-    """Return diagnostic information from the debug service."""
+def get_debug_summary() -> Dict[str, Any]:
+    """Return diagnostic information gathered from the ML debug pipeline."""
+
     return DebugService().do_debug()

--- a/backend/routes/debug.py
+++ b/backend/routes/debug.py
@@ -5,4 +5,5 @@ router = APIRouter()
 
 @router.get("/")
 def get_debug_summary():
+    """Return diagnostic information from the debug service."""
     return DebugService().do_debug()


### PR DESCRIPTION
## Summary
- rename the FastAPI debug route handler to `get_debug_summary` to better describe its purpose

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f356e3b04883259654b38a71eecd3e